### PR TITLE
Se corrige el nombre de la categoría de operaciones de cartas por mazos

### DIFF
--- a/Proyectos/5.Algoritmos sobre listas/1.Contar las cartas entre bambalinas/meta.yml
+++ b/Proyectos/5.Algoritmos sobre listas/1.Contar las cartas entre bambalinas/meta.yml
@@ -16,7 +16,7 @@ blocks:
         <block type="OperadorNumerico"></block>
         <block type="not"></block>
     </category>
-    <category name="Operaciones de cartas">
+    <category name="Operaciones de mazos">
         <block type="mazoActual"></block>
         <block type="quedanCartas_"></block>
         <block type="dameLaPrimeraCartaDe_"></block>


### PR DESCRIPTION
Se corrige la categoría "Operaciones de cartas" por "Operaciones de mazos" en el ejercicio 5.1.Contar las cartas entre bambalinas